### PR TITLE
New "model" command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- [NEW] Add model command to show make, model, and serial of a device
+- [NEW] Add option to showrack to display make, model, and serial of each
+        device.
 - [IMPROVED] Add GET response caching for performance/testing
 
 0.0.1 (2017-09-13)

--- a/dcim/api.py
+++ b/dcim/api.py
@@ -9,16 +9,23 @@ many times as it will not make use of TLS connection pooling and keep-alive.
 from dcim.client import DCIMClient
 
 
-def locate(device):
-    with DCIMClient() as client:
-        return client.locate(device)
+def locate(*args, **kwargs):
+    with DCIMClient(caching=True) as client:
+        return client.locate(*args, **kwargs)
 
 locate.__doc__ = DCIMClient.locate.__doc__
 
 
-def showrack(location, display=False, width=72):
-    with DCIMClient() as client:
-        return client.showrack(location, display=display, width=width)
+def model(*args, **kwargs):
+    with DCIMClient(caching=True) as client:
+        return client.model(*args, **kwargs)
+
+model.__doc__ = DCIMClient.model.__doc__
+
+
+def showrack(*args, **kwargs):
+    with DCIMClient(caching=True) as client:
+        return client.showrack(*args, **kwargs)
 
 showrack.__doc__ = DCIMClient.showrack.__doc__
     

--- a/tests/assets/client_responses.py
+++ b/tests/assets/client_responses.py
@@ -109,6 +109,35 @@ DEFAULT_DEVICE = {
     'v3SecurityLevel': 'noAuthNoPriv'
 }
 
+DEFAULT_MANUFACTURER = {
+    'GlobalID': '0',
+    'ManufacturerID': '1',
+    'Name': 'Ringo',
+    'SubscribeToUpdates': '0'
+}
+
+DEFAULT_TEMPLATE = {
+    'ChassisSlots': 0,
+    'CustomValues': [],
+    'DeviceType': 'Server',
+    'FrontPictureFile': 'ringo-r730-front.png',
+    'GlobalID': 1,
+    'Height': 1,
+    'KeepLocal': 0,
+    'ManufacturerID': 1,
+    'Model': 'PowerDrum R730',
+    'Notes': '',
+    'NumPorts': 5,
+    'PSCount': 2,
+    'RearChassisSlots': 0,
+    'RearPictureFile': 'ringo-r730-rear.png',
+    'SNMPVersion': '2c',
+    'ShareToRepo': 0,
+    'TemplateID': 1,
+    'Wattage': 400,
+    'Weight': 85
+}
+
 
 def populate_cache():
     """
@@ -118,6 +147,20 @@ def populate_cache():
     function for testing.
     """
     cache = {}
+
+    ringo = deepcopy(DEFAULT_MANUFACTURER)
+    r = construct_json_response(
+        {'error': False, 'errorcode': 200, 'manufacturer': [ringo]},
+        200
+    )
+    cache[('api/v1/manufacturer', frozenset({}.items()))] = r
+
+    r730 = deepcopy(DEFAULT_TEMPLATE)
+    r = construct_json_response(
+        {'error': False, 'errorcode': 200, 'template': r730},
+        200
+    )
+    cache[('api/v1/devicetemplate/1', frozenset({}.items()))] = r
 
     dcFoo101 = deepcopy(DEFAULT_DATACENTER)
     r = construct_json_response(
@@ -155,6 +198,7 @@ def populate_cache():
     node102['Height'] = 1
     node102['Label'] = 'node102'
     node102['Position'] = 2
+    node102['TemplateID'] = 0
     r = construct_json_response(
         {'error': False, 'errorcode': 200, 'device': [node102]},
         200

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -42,6 +42,27 @@ class TestClientLocate:
         assert client.locate('node103') == expected
 
 
+class TestClientModel:
+    """
+    Tests for the DCIMClient.model method
+    """
+    def test_no_template(self, client):
+        expected = {
+            'make': None,
+            'model': None,
+            'serial': 'ABCDEFGH'
+        }
+        assert client.model('node102') == expected
+
+    def test_template(self, client):
+        expected = {
+            'make': 'Ringo',
+            'model': 'PowerDrum R730',
+            'serial': 'ABCDEFGH'
+        }
+        assert client.model('node101') == expected
+
+
 class TestClientShowrack:
     """
     Tests for the client showrack function


### PR DESCRIPTION
Add a new model command to display the make, model, and serial number of a node. Incorporate this functionality into the showrack command as an option.

Example usage:

```
$ dcim model vmp1388
vmp1388: Dell DSS1500 SN: XXXXXXX

$ dcim showrack H12 --model
---snip---
+----+----------------------------------------------------------------+
|U034|| vmp1421 [Dell DSS1500 SN: XXXXXXX]                           ||
+----+----------------------------------------------------------------+
|U033|| vmp1420 [Dell DSS1500 SN: XXXXXXX]                           ||
+----+----------------------------------------------------------------+
|U032|| vmp1419 [Dell DSS1500 SN: XXXXXXX]                           ||
+----+----------------------------------------------------------------+
|U031|| vmp1418 [Dell DSS1500 SN: XXXXXXX]                           ||
+----+----------------------------------------------------------------+
```