### PR TITLE
Add a simple dhcpd.conf file parser

### DIFF
--- a/dcim/util.py
+++ b/dcim/util.py
@@ -2,6 +2,7 @@
 General stand-alone utility functions for internal package use
 """
 import re
+import string
 
 
 BRACKETRANGE_RE = re.compile(r"\[([0-9]+-[0-9]+)\]")
@@ -51,7 +52,7 @@ def draw_rack(
 
     spacer = '+----+' + '-'*width + '+'
     emptyslot = '|    |' + ' '*width + '|'
-    
+
     drawing = []
     u = 1
     device_top = True
@@ -86,3 +87,239 @@ def draw_rack(
             print(line)
 
     return drawing
+
+
+class DHCPDHostParser(dict):
+    """
+    Used to parse host blocks out of dchpd configuration files
+    for easy access to IPs and MACs in a dictionary format.
+
+    For example, if a dchpd.conf file had a host block like the following::
+
+        host node099 {
+            hardware ethernet 54:1A:77:2f:70:4d;
+            fixed-address 10.0.18.3;
+            option domain-name-servers 192.168.128.10;
+            option host-name "node099.example.com";
+        }
+
+    Then parsing the file with the parser object would result in the
+    following dict set to the key ``parser['node099']`` after parsing
+    the file::
+
+        {
+            'hardware ethernet': '54:1A:77:2f:70:4d',
+            'fixed-address': '10.0.18.3',
+            'option domain-name-servers': '192.168.128.10',
+            'option host-name': 'node099.example.com'
+        }
+
+    Note that repeated declarations or parameters in a single host block
+    will result in clobbering the first declaration, as will multiple
+    host blocks in the same stream. This simple parser is based on
+    my very limited understanding of dhcpd conf syntax!
+    """
+    def __init__(self, stream=None):
+        """
+        Initialize the parser state. If a stream is given it is parsed
+        and hosts added to the object dict.
+
+        :param stream stream: File-like object to read and parse
+        """
+        if stream is not None:
+            self.parse(stream)
+
+    def parse(self, stream):
+        """
+        Parse a file-like dchpd.conf object and load the declarations
+        from all host blocks into the object dictionary keyed by
+        host.
+
+        :param stream stream: file-like dchpd.conf object open for reading
+        """
+        self.tokenize(stream)
+        self.parse_tokens()
+
+    def parse_tokens(self, tokenlist=None):
+        """
+        Parse a list of dchpd.conf token strings and load the declarations
+        from all host blocks into the object dictionary keyed by
+        host. If no list is given use the previous results of the
+        ``tokenize`` method.
+
+        :param list(str) tokenlist: list of dhcpd.conf token strings
+        """
+        if tokenlist is not None:
+            self.t_result = tokenlist
+
+        self.p_munch_func = self._p_munch_normal
+        self.t_result.reverse()
+
+        while self.t_result:
+            self.p_munch_func()
+
+    def _p_munch_normal(self):
+        """munch tokens and change state if it's "host" """
+        token = self.t_result.pop()
+        if token == 'host':
+            self.p_munch_func = self._p_munch_host
+
+    def _p_munch_host(self):
+        """parse a host block and add to internal dict"""
+        # next token should be the hostname
+        self.cur_hostname = self.t_result.pop()
+        self[self.cur_hostname] = {}
+
+        if self.t_result.pop() != '{':
+            raise ValueError(
+                'Expected open curly-brace after host {}'.format(hostname)
+            )
+
+        self.p_munch_func = self._p_munch_host_entry
+
+    def _p_munch_host_entry(self):
+        """parse an entry within a host block"""
+        token = self.t_result.pop()
+
+        # end of host block
+        if token == '}':
+            self.p_munch_func = self._p_munch_normal
+            return
+
+        # empty host entry line
+        if token == ';':
+            return
+
+        # if the token is 'hardware' or 'option' then combine with the
+        # next token for convienience
+        if token == 'hardware' or token == 'option':
+            token = '{} {}'.format(token, self.t_result.pop())
+
+        key = token
+        val = []
+        token = self.t_result.pop()
+        while token != ';':
+            val.append(token)
+            token = self.t_result.pop()
+
+        self[self.cur_hostname][key] = ' '.join(val)
+
+    def tokenize(self, stream):
+        """
+        Read a file-like object and break into a list of tokens corresponding
+        to the (approximate) dhcpd.conf file grammar. Comments are removed
+        completely, non-quoted words lowercased, whitespace removed, curly
+        braces and semicolons separated into their own tokens. The list of
+        tokens is returned and set to the object attribute ``t_result``.
+
+        Internally, the tokenizer is set up as a finite state machine. The
+        raw string is munched character by character, with the current token
+        being built in the ``cur_token`` attribute. For each character
+        a function is called to munch the character, and the specific function
+        to be called is determined by the current state: normal, comment,
+        squote, dquote, or postquote. A reference to the function for the
+        current state is held in the attribute ``t_munch_func``.
+
+        :param stream stream: File-like object to read and tokenize:
+
+        :returns: List of dhcpd.conf token strings
+        :rtype: list(str)
+        """
+        self.t_munch_func = self._munch_normal
+        self.t_result = []
+        self.cur_token = []
+
+        raw_string = list(stream.read())
+
+        idx = 1
+        line = 1
+        for char in raw_string:
+            self.t_munch_func(char, idx, line)
+            if char == '\n':
+                line += 1
+                idx = 1
+            else:
+                idx += 1
+        return self.t_result
+
+    def _t_push_token(self, extender=''):
+        """
+        Pushes the current token onto the result list along with
+        the additional string extender added to the token, if the
+        current token is nonempty. Resets the current token to empty.
+        """
+        for char in extender:
+            self.cur_token.append(char)
+        if self.cur_token:
+            self.t_result.append(''.join(self.cur_token))
+        self.cur_token = []
+
+    def _munch_normal(self, char, idx, line):
+        """munch next character in NORMAL state"""
+        if char == '\'':
+            if self.cur_token:
+                raise ValueError(
+                    'Unexpected quote at line {} position {}'
+                    .format(line, idx)
+                )
+            self.t_munch_func = self._munch_squote
+
+        elif char == '"':
+            if self.cur_token:
+                raise ValueError(
+                    'Unexpected quote at line {} position {}'
+                    .format(line, idx)
+                )
+            self.t_munch_func = self._munch_dquote
+
+        elif char in string.whitespace:
+            self._t_push_token()
+
+        elif char in ',;':
+            self._t_push_token()
+            self._t_push_token(char)
+
+        elif char == '#':
+            self._t_push_token()
+            self.t_munch_func = self._munch_comment
+
+        else:
+            self.cur_token.append(char.lower())
+
+    def _munch_comment(self, char, idx, line):
+        """munch next character in COMMENT state"""
+        if char == '\n':
+            self.t_munch_func = self._munch_normal
+
+    def _munch_squote(self, char, idx, line):
+        """munch next character in SQUOTE state"""
+        if char == '\'':
+            self._t_push_token()
+            self.t_munch_func = self._munch_postquote
+        else:
+            self.cur_token.append(char)
+
+    def _munch_dquote(self, char, idx, line):
+        """munch next character in DQUOTE state"""
+        if char == '"':
+            self._t_push_token()
+            self.t_munch_func = self._munch_postquote
+        else:
+            self.cur_token.append(char)
+
+    def _munch_postquote(self, char, idx, line):
+        """munch next character in POSTQUOTE state"""
+        allowed = string.whitespace + ',;#'
+        if char not in allowed:
+            raise ValueError(
+                'Unexpected character {} after close quote at line {} pos {}'
+                .format(char, line, idx)
+            )
+
+        elif char in ',;':
+            self._t_push_token(char)
+            self.t_munch_func = self._munch_normal
+        elif char == '#':
+            self.t_munch_func = self._munch_comment
+        else:
+            self.t_munch_func = self._munch_normal

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,11 +1,13 @@
 """
 Tests for the utils module
 """
+from io import StringIO
 from textwrap import dedent
 
 from dcim.util import (
     expand_brackets,
-    draw_rack
+    draw_rack,
+    DHCPDHostParser,
 )
 
 
@@ -118,3 +120,177 @@ class TestDrawRack:
         )
 
         assert expected == '\n'.join(result)
+
+
+class TestDHCPDHostParser:
+    """
+    Tests for the util.DCHPDHostParser class
+    """
+    def test_tokenize_valid_block(self):
+        dhcpd_raw = """\
+            # 10.0.5.1/24 - x250b-4g-u44 - vlan12
+            pool {
+              deny members of "IPMI";
+              allow members of "vlan12";
+              option routers 10.0.12.1;
+              option subnet-mask 255.255.255.0;
+              option classless-static-routes 20.10.0 10.0.12.1, 0 10.0.12.1;
+              default-lease-time 1800; # 30 min 
+              max-lease-time 3600; # 1 hr
+              range 10.0.12.131 10.0.12.220;
+            }
+        """
+        dhcpd_stream = StringIO(dedent(dhcpd_raw))
+
+        expected = [
+            'pool', '{',
+            'deny', 'members', 'of', 'IPMI', ';',
+            'allow', 'members', 'of', 'vlan12', ';',
+            'option', 'routers', '10.0.12.1', ';',
+            'option', 'subnet-mask', '255.255.255.0', ';',
+            'option', 'classless-static-routes', '20.10.0',
+                '10.0.12.1', ',', '0', '10.0.12.1', ';',
+            'default-lease-time', '1800', ';',
+            'max-lease-time', '3600', ';',
+            'range', '10.0.12.131', '10.0.12.220', ';',
+            '}'
+        ]
+
+        parser = DHCPDHostParser()
+
+        assert parser.tokenize(dhcpd_stream) == expected
+
+    def test_tokenize_valid_block2(self):
+        dhcpd_raw = """\
+            ########################################################
+            ## Brood 7 (node081-node120)
+            ########################################################
+
+            use-host-decl-names on;
+
+            group {
+
+                option routers 10.0.18.1;
+                option subnet-mask 255.255.252.0;
+                option classless-static-routes 42.10.0 10.0.18.1;
+
+                    host node098 {
+                           hardware ethernet 54:1A:77:2f:70:10;
+                    fixed-address 10.0.18.2;
+                    }
+                    host node099 {
+                           hardware ethernet 54:1A:77:2f:70:4d;
+                    fixed-address 10.0.18.3;
+                    }
+            }
+        """
+        dhcpd_stream = StringIO(dedent(dhcpd_raw))
+
+        expected = [
+            'use-host-decl-names', 'on', ';',
+            'group', '{',
+            'option', 'routers', '10.0.18.1', ';',
+            'option', 'subnet-mask', '255.255.252.0', ';',
+            'option', 'classless-static-routes', '42.10.0', '10.0.18.1', ';',
+            'host', 'node098', '{',
+            'hardware', 'ethernet', '54:1a:77:2f:70:10', ';',
+            'fixed-address', '10.0.18.2', ';',
+            '}',
+            'host', 'node099', '{',
+            'hardware', 'ethernet', '54:1a:77:2f:70:4d', ';',
+            'fixed-address', '10.0.18.3', ';',
+            '}',
+            '}'
+        ]
+
+        parser = DHCPDHostParser()
+
+        assert parser.tokenize(dhcpd_stream) == expected
+
+    def test_parse_two_hosts(self):
+
+        tokenlist = [
+            'use-host-decl-names', 'on', ';',
+            'group', '{',
+            'option', 'routers', '10.0.18.1', ';',
+            'option', 'subnet-mask', '255.255.252.0', ';',
+            'option', 'classless-static-routes', '42.10.0', '10.0.18.1', ';',
+            'host', 'node098', '{',
+            'hardware', 'ethernet', '54:1a:77:2f:70:10', ';',
+            'fixed-address', '10.0.18.2', ';',
+            '}',
+            'host', 'node099', '{',
+            'hardware', 'ethernet', '54:1a:77:2f:70:4d', ';',
+            'fixed-address', '10.0.18.3', ';',
+            '}',
+            '}'
+        ]
+
+        parser = DHCPDHostParser()
+        parser.parse_tokens(tokenlist)
+
+        assert len(parser) == 2
+
+        assert parser['node098']['hardware ethernet'] == '54:1a:77:2f:70:10'
+        assert parser['node098']['fixed-address'] == '10.0.18.2'
+
+        assert parser['node099']['hardware ethernet'] == '54:1a:77:2f:70:4d'
+        assert parser['node099']['fixed-address'] == '10.0.18.3'
+
+    def test_tokenize_and_parse_valid_block2(self):
+        dhcpd_raw = """\
+            ########################################################
+            ## Brood 7 (node081-node120)
+            ########################################################
+
+            use-host-decl-names on;
+
+            group {
+
+                option routers 10.0.18.1;
+                option subnet-mask 255.255.252.0;
+                option classless-static-routes 42.10.0 10.0.18.1;
+
+                    host node098 {
+                           hardware ethernet 54:1A:77:2f:70:10;
+                    fixed-address 10.0.18.2;
+                    }
+                    host node099 {
+                           hardware ethernet 54:1A:77:2f:70:4d;
+                    fixed-address 10.0.18.3;
+                    }
+            }
+        """
+        dhcpd_stream = StringIO(dedent(dhcpd_raw))
+
+        parser = DHCPDHostParser()
+        parser.parse(dhcpd_stream)
+
+        assert len(parser) == 2
+
+        assert parser['node098']['hardware ethernet'] == '54:1a:77:2f:70:10'
+        assert parser['node098']['fixed-address'] == '10.0.18.2'
+
+        assert parser['node099']['hardware ethernet'] == '54:1a:77:2f:70:4d'
+        assert parser['node099']['fixed-address'] == '10.0.18.3'
+
+    def tokenize_and_parse_with_option(self):
+        dhcpd_raw = """\
+            host node099 {
+                hardware ethernet 54:1A:77:2f:70:4d;
+                fixed-address 10.0.18.3;
+                option domain-name-servers 192.168.128.10;
+                option host-name "node099.example.com";
+            }
+        """
+        dhcpd_stream = StringIO(dedent(dhcpd_raw))
+
+        parser = DHCPDHostParser()
+        parser.parse(dhcpd_stream)
+
+        assert len(parser) == 1
+
+        assert parser['node099']['hardware ethernet'] == '54:1A:77:2f:70:4d'
+        assert parser['node099']['fixed-address'] == '10.0.18.3'
+        assert parser['node099']['option domain-name-servers'] == '192.168.128.10'
+        assert parser['node099']['option host-name'] == 'node099.example.com'


### PR DESCRIPTION
Add a simple dhcpd.conf file parsing utility class that can potentially be used to import and
or audit IP/MAC address information and compare to inventory.

Given that we have some/all of this information derived from configuration management, this may be of more limited utility than I first expected. It might still be helpful in auditing dhcpd configuration against the inventory database.

From the class docstring:


For example, if a dchpd.conf file had a host block like the following::

        host node099 {
            hardware ethernet 54:1A:77:2f:70:4d;
            fixed-address 10.0.18.3;
            option domain-name-servers 192.168.128.10;
            option host-name "node099.example.com";
        }

 Then parsing the file with the parser object would result in the following dict set to the key `parser['node099']` after parsing the file:

        {
            'hardware ethernet': '54:1A:77:2f:70:4d',
            'fixed-address': '10.0.18.3',
            'option domain-name-servers': '192.168.128.10',
            'option host-name': 'node099.example.com'
        }
