### PR TITLE
Add audits module and a device label audit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Unreleased
 ==========
 
+- [NEW] Add device label audit class
+- [NEW] Add audits module
+- [NEW] Add get_device_by_id method to client
+- [NEW] Add device label normalization function
 - [NEW] Add dhcpd configuration file parser
 - [NEW] Add model command to show make, model, and serial of a device
 - [NEW] Add option to showrack to display make, model, and serial of each

--- a/dcim/audits.py
+++ b/dcim/audits.py
@@ -1,0 +1,120 @@
+"""
+Audits are functions that consider the state of the OpenDCIM database
+as a whole against policies or other sources of information, and
+ensure that the information in the database matches the policy or
+information source.
+
+All reports return a dict with three fields: a ``result`` field with
+a value of ``OK``, ``Repaired``, or ``Error``; an ``errors`` field
+with a list of problems that could not or were not repaired, and
+a ``repairs`` field with a list of repairs performed.
+"""
+from collections import defaultdict
+
+from dcim.client import DCIMClient
+from dcim.util import normalize_label, VALID_LABEL_RE
+
+
+class DCIMAudit:
+    """
+    Base class for all audits setting up attributes to store error
+    and repair messages, and handle making the final report.
+
+    Audits are performed by calling the ``perform`` method which is
+    defined in all subclasses, and should return the result of the
+    ``_complete`` method.
+    """
+    def __init__(self):
+        self.errors = []
+        self.repairs = []
+
+    def perform(self):
+        """
+        Perform a noop audit. This method should be overridden in
+        subclasses.
+
+        :returns: Audit report
+        :rtype: dict
+        """
+        return self._complete()
+
+    def _complete(self):
+        """
+        Compile a result dict from the errors and repairs lists
+        """
+        result = {}
+        if not (self.errors or self.repairs):
+            result['result'] = 'OK'
+        elif not self.errors:
+            result['result'] = 'Repaired'
+        else:
+            result['result'] = 'Error'
+
+        result['errors'] = self.errors
+        result['repairs'] = self.repairs
+        return result
+        
+
+class AuditDeviceLabels(DCIMAudit):
+    """
+    Ensure that all device labels follow the policy of containing only
+    characters a-z, 0-9, and non-repeated ``-``s. In addition, check for
+    any duplicate labels.
+    """
+    def perform(self, repair=False):
+        """
+        Check all devices and list any that do not follow the valid label
+        policy of containing only a-z, 0-9, and non-repeated ``-``s. If
+        ``repair`` is set to True, change labels to follow the policy
+        if possible and mark an error otherwise. Find duplicate labels and
+        list these as errors.
+
+        :param bool repair: If True, try to modify device labels to follow
+            policy
+        :returns: Audit report
+        :rtype: dict
+        """
+        self.client = DCIMClient()
+        self.found_labels = defaultdict(list)
+
+        devs = self.client.get_all_devices()
+        for device in devs:
+            self._check_device_label(device, repair=repair)
+
+        for label in self.found_labels:
+            if len(self.found_labels[label]) > 1:
+                self.errors.append(
+                    'Duplicate label "{}" for device IDs: {}'
+                    .format(label, self.found_labels[label])
+                )
+
+        return self._complete()
+
+    def _check_device_label(self, device, repair=False):
+        """audit the label of a single specified device"""
+        label = device['Label']
+        devid = device['DeviceID']
+
+        if VALID_LABEL_RE.search(label):
+            self.found_labels[label].append(devid)
+        elif repair:
+            try:
+                new_label = normalize_label(label)
+                self.client.update_device_by_id(devid, {'Label': new_label})
+                self.found_labels[new_label].append(devid)
+                self.repairs.append(
+                    'Modified device label for {}, "{}" --> "{}"'
+                    .format(devid, label, new_label)
+                )
+            except ValueError:
+                self.found_labels[label].append(devid)
+                self.errors.append(
+                    'Invalid and uncorrectable label "{}" for device {}'
+                    .format(label, devid)
+                )
+        else:
+            self.found_labels[label].append(devid)
+            self.errors.append(
+                'Invalid label "{}" for device {}'
+                .format(label, devid)
+            )

--- a/dcim/client.py
+++ b/dcim/client.py
@@ -107,6 +107,21 @@ class DCIMClient(object):
         resp = self._get('api/v1/device')
         return resp.json()['device']
 
+    def update_device_by_id(self, device_id, updates):
+        """
+        Update fields of a device given by DeviceID with values
+        specifed in a dict.
+
+        :param str|int device_id: DCIM id of a device to update
+        :param dict updates: fields to be updated and new values
+        """
+        resp = self._request(
+            'POST',
+            'api/v1/device/{}'.format(device_id),
+            json=updates
+        )
+        resp.raise_for_status()
+
     def locate(self, device):
         """
         Returns the datacenter, cabinet, and rack position of the specified

--- a/dcim/client.py
+++ b/dcim/client.py
@@ -78,12 +78,16 @@ class DCIMClient(object):
 
         return self._request('GET', path, **kwargs)
 
-    def _get_device(self, device):
+    def get_device(self, device):
         """
         Return device information for a device by label.
 
         Note that if multiple devices share the same label, only the first
         device will be returned.
+
+        :param str device: Label of the device
+        :returns: Information about the device
+        :rtype: dict
         """
         resp = self._get('api/v1/device', params={'Label': device})
         try:
@@ -92,6 +96,16 @@ class DCIMClient(object):
             raise DCIMNotFoundError(
                 'Device label {} was not found.'.format(device)
             ) from None
+
+    def get_all_devices(self):
+        """
+        Return device information for all devices in OpenDCIM
+
+        :returns: Information about all devices
+        :rtype: list(dict)
+        """
+        resp = self._get('api/v1/device')
+        return resp.json()['device']
 
     def locate(self, device):
         """
@@ -107,7 +121,7 @@ class DCIMClient(object):
             and a list of parent devices.
         :rtype: dict
         """
-        dev_info = self._get_device(device)
+        dev_info = self.get_device(device)
 
         parents = []
         while dev_info['ParentDevice']:
@@ -213,7 +227,7 @@ class DCIMClient(object):
         :rtype: dict
         """
         if dev_info is None:
-            dev_info = self._get_device(device)
+            dev_info = self.get_device(device)
         template = dev_info['TemplateID']
         serial = dev_info['SerialNo']
         if not template:

--- a/dcim/util.py
+++ b/dcim/util.py
@@ -6,6 +6,7 @@ import string
 
 
 BRACKETRANGE_RE = re.compile(r"\[([0-9]+-[0-9]+)\]")
+VALID_LABEL_RE = re.compile(r"^[a-z0-9-]*$")
 
 
 def expand_brackets(input_string):
@@ -87,6 +88,31 @@ def draw_rack(
             print(line)
 
     return drawing
+
+
+def normalize_label(raw_label):
+    """
+    Normalize a label (str) to a policy of only containing lowercase
+    letters (a-z), numbers, and ``-``. Remove leading or trailing
+    whitespace, lowercase letters, and replace internal whitespace,
+    underscores, dots, or colons  with a single ``-`` character
+    between letters. Return the resulting normalized label.
+
+    If the label cannot be normalized in this manner, raise a ValueError.
+
+    :param str raw_label: Device label to be normalized
+    :returns: Normalized label
+    """
+    label = raw_label.strip().lower()
+    label = re.sub(r"[\s\-_\.:]+", '-', label)
+
+    if not VALID_LABEL_RE.search(label):
+        raise ValueError(
+            'Label "{}" could not be normalized to contain only a-z, 0-9, '
+            'and "-" using the available rules.'.format(raw_label)
+        )
+
+    return label
 
 
 class DHCPDHostParser(dict):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,9 +4,12 @@ Tests for the utils module
 from io import StringIO
 from textwrap import dedent
 
+import pytest
+
 from dcim.util import (
     expand_brackets,
     draw_rack,
+    normalize_label,
     DHCPDHostParser,
 )
 
@@ -120,6 +123,22 @@ class TestDrawRack:
         )
 
         assert expected == '\n'.join(result)
+
+
+class TestNormalizeLabel:
+    """
+    Tests for the normalize label function
+    """
+    def test_already_normalized(self):
+        assert normalize_label('x11-a22-b-9') == 'x11-a22-b-9'
+    def test_normalize_case1(self):
+        assert normalize_label('SM_29 H11') == 'sm-29-h11'
+    def test_normalize_case2(self):
+        assert normalize_label('ToR--G3 Dell X290.a') == 'tor-g3-dell-x290-a'
+    def test_not_normalizable(self):
+        with pytest.raises(ValueError) as cm:
+            normalize_label('G3**_+;')
+        assert 'G3**_+;' in str(cm.value)
 
 
 class TestDHCPDHostParser:


### PR DESCRIPTION
Add a general purpose audits model to check the status of the OpenDCIM database against general policy or other information source and optionally make repairs.

Add a DeviceLabels audit which checks for duplicate or invalid device labels, and corrects invalid labels for uppercase letters and whitespace.

Generally tested manually after backing up the OpenDCIM database.