### PR TITLE
Fix bug with repeated label audit perform calls

### DIFF
--- a/dcim/audits.py
+++ b/dcim/audits.py
@@ -88,6 +88,9 @@ class AuditDeviceLabels(DCIMAudit):
                     .format(label, self.found_labels[label])
                 )
 
+        # clear found_labels for subsequent uses of the perform method
+        self.found_labels = defaultdict(list)
+
         return self._complete()
 
     def _check_device_label(self, device, repair=False):


### PR DESCRIPTION
Fix a bug where if the perform method of the label
audit class is repeatedly called, it will retain information
about labels from the last invocation.