### PR TITLE
Add -s/--serial option to locate command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Unreleased
 ==========
 
+- [NEW] Add --serial option to locate devices by SerialNo
 - [IMPROVED] Better CLI help messaging and version info
 
 0.2.0 (2017-12-14)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -28,7 +28,8 @@ class TestClientLocate:
             'datacenter': 'Foo 101',
             'cabinet': 'A01',
             'position': 1,
-            'parent_devices': []
+            'parent_devices': [],
+            'label': 'node101'
         }
         assert client.locate('node101') == expected
 
@@ -37,7 +38,8 @@ class TestClientLocate:
             'datacenter': 'Foo 101',
             'cabinet': 'A01',
             'position': 4,
-            'parent_devices': ['chassisA']
+            'parent_devices': ['chassisA'],
+            'label': 'node103'
         }
         assert client.locate('node103') == expected
 


### PR DESCRIPTION
This option allows for locating a device by its serial number rather than its label.

See Issue #9

CLI manual testing:
```
(venv) eric@laptop:OpenDCIMPython (feature/locate-by-serial)$ dcim locate vmp1234
vmp1234: Hill 107, H06, U34
(venv) eric@laptop:OpenDCIMPython (feature/locate-by-serial)$ dcim locate -s B6JCW52
vmp1234: Hill 107, H06, U34
(venv) eric@laptop:OpenDCIMPython (feature/locate-by-serial)$ dcim locate --serial B6JCW52
vmp1234: Hill 107, H06, U34
```